### PR TITLE
map whole config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ anisette-v3) but it can also be used with AltServer-Linux.
 ## Run using Docker
 
 ```bash
-docker run -d --restart always --name anisette-v3 -p 6969:6969 --volume anisette-v3_data:/home/Alcoholic/.config/anisette-v3/lib/ dadoum/anisette-v3-server
+docker run -d --restart always --name anisette-v3 -p 6969:6969 --volume anisette-v3_data:/home/Alcoholic/.config/anisette-v3/ dadoum/anisette-v3-server
 ```
 
 ## Compile using dub


### PR DESCRIPTION
The example docker run command maps the local volume to the lib subdirectory, causing the machine configuration files to not be backed up on the host. I suggest removing lib/.

Note that when mapping the configuration files, the directory and file permissions must match uid/gid 1000 on the host for the container to be able to write the files. docker logs anisette-v3 will indicate such problems if the container doesn't start.