### PR TITLE
[feat] Add "Deploy to Render" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A supposedly lighter alternative to [omnisette-server](https://github.com/SideSt
 Like `omnisette-server`, it supports both currently supported SideStore's protocols (anisette-v1 and 
 anisette-v3) but it can also be used with AltServer-Linux.
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Dadoum/anisette-v3-server)
+
 ## Run using Docker
 
 ```bash

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+version: "1"
+services:
+- type: web
+  name: anisette-v3-server
+  runtime: image
+  image:
+    url: dadoum/anisette-v3-server
+  plan: free
+  region: ohio
+  autoDeploy: false


### PR DESCRIPTION
Adds:
- `render.yaml` Render Blueprint file
- <kbd>Deploy to Render</kbd> button in README

Thus people can conveniently deploy without their own fork, pulling the prebuilt image from upstream, with a single click<sup>[1]</sup>.

[1] Not really, since they'd still need to do some stuff over at Render, but this is much more streamlined than the instructions at <https://docs.sidestore.io/docs/advanced/anisette/>