### PR TITLE
fix: create default provisioning folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates
 WORKDIR /opt/
 COPY --from=builder /opt/anisette-v3-server /opt/anisette-v3-server
 
+# Create default provisioning folder
+RUN mkdir -p mkdir -p /opt/anisette-v3/provisioning
+
 # Setup rootless user which works with the volume mount
 RUN useradd -ms /bin/bash Alcoholic \
  && mkdir /home/Alcoholic/.config/anisette-v3/lib/ -p \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /opt/
 COPY --from=builder /opt/anisette-v3-server /opt/anisette-v3-server
 
 # Create default provisioning folder
-RUN mkdir -p mkdir -p /opt/anisette-v3/provisioning
+RUN mkdir -p /opt/anisette-v3/provisioning
 
 # Setup rootless user which works with the volume mount
 RUN useradd -ms /bin/bash Alcoholic \


### PR DESCRIPTION
Fixes the issue reported in https://github.com/Dadoum/anisette-v3-server/issues/42 by creating the default provisioning folder at `/opt/anisette-v3/provisioning` when running in docker.

Thanks to https://github.com/Dadoum/anisette-v3-server/issues/38#issuecomment-2990620992 for the lead.