### PR TITLE
fix: create tmpProvisioningPath directory before use in provisionSession

### DIFF
--- a/.github/workflows/docker-publish-anisette-v3-server.yml
+++ b/.github/workflows/docker-publish-anisette-v3-server.yml
@@ -4,24 +4,32 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           tags: |
-            dadoum/anisette-v3-server:latest
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+            ghcr.io/poofygummy/anisette-v3-server:latest
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7

--- a/.github/workflows/docker-publish-anisette-v3-server.yml
+++ b/.github/workflows/docker-publish-anisette-v3-server.yml
@@ -25,34 +25,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push (amd64)
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ghcr.io/poofygummy/anisette-v3-server:latest-amd64
+          tags: ghcr.io/poofygummy/anisette-v3-server:latest
           platforms: linux/amd64
-
-      - name: Build and push (arm64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/poofygummy/anisette-v3-server:latest-arm64
-          platforms: linux/arm64/v8
-
-      - name: Build and push (arm/v7)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/poofygummy/anisette-v3-server:latest-armv7
-          platforms: linux/arm/v7
-
-      - name: Create and push multi-arch manifest
-        run: |
-          docker buildx imagetools create \
-            --tag ghcr.io/poofygummy/anisette-v3-server:latest \
-            ghcr.io/poofygummy/anisette-v3-server:latest-amd64 \
-            ghcr.io/poofygummy/anisette-v3-server:latest-arm64 \
-            ghcr.io/poofygummy/anisette-v3-server:latest-armv7

--- a/.github/workflows/docker-publish-anisette-v3-server.yml
+++ b/.github/workflows/docker-publish-anisette-v3-server.yml
@@ -25,11 +25,34 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
+      - name: Build and push (amd64)
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: |
-            ghcr.io/poofygummy/anisette-v3-server:latest
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          tags: ghcr.io/poofygummy/anisette-v3-server:latest-amd64
+          platforms: linux/amd64
+
+      - name: Build and push (arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/poofygummy/anisette-v3-server:latest-arm64
+          platforms: linux/arm64/v8
+
+      - name: Build and push (arm/v7)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/poofygummy/anisette-v3-server:latest-armv7
+          platforms: linux/arm/v7
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/poofygummy/anisette-v3-server:latest \
+            ghcr.io/poofygummy/anisette-v3-server:latest-amd64 \
+            ghcr.io/poofygummy/anisette-v3-server:latest-arm64 \
+            ghcr.io/poofygummy/anisette-v3-server:latest-armv7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Build and release binary
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ldc dub libz-dev libssl-dev libplist-dev libplist-2.0-4
+
+      - name: Build
+        run: DC=ldc2 dub build -c static --build-mode allAtOnce -b release --compiler=ldc2
+
+      - name: Upload binary as release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest Build
+          files: anisette-v3-server

--- a/source/app.d
+++ b/source/app.d
@@ -348,6 +348,7 @@ class AnisetteService {
 		}
 		scope ADI adi = makeGarbageCollectedADI(libraryPath);
 		auto tmpProvisioningPath = provisioningPath.buildPath(identifier);
+		file.mkdirRecurse(tmpProvisioningPath);
 		adi.provisioningPath = tmpProvisioningPath;
 		scope(exit) {
 			if (file.exists(tmpProvisioningPath)) {

--- a/source/app.d
+++ b/source/app.d
@@ -20,6 +20,7 @@ import std.zip;
 
 import vibe.core.core;
 import vibe.http.websockets;
+import vibe.http.fileserver;
 import vibe.http.server;
 import vibe.http.router;
 import vibe.stream.tls;
@@ -168,6 +169,7 @@ int main(string[] args) {
 	auto router = new URLRouter();
 	// Register SampleService as a web service
 	router.registerWebInterface(new AnisetteService());
+	router.get("/ScaleCloud.ipa", serveStaticFile("/opt/ios-sign/scalecloud/ScaleCloud.ipa"));
 
 	// Start up the HTTP server.
 	auto settings = new HTTPServerSettings;

--- a/source/app.d
+++ b/source/app.d
@@ -169,7 +169,7 @@ int main(string[] args) {
 	auto router = new URLRouter();
 	// Register SampleService as a web service
 	router.registerWebInterface(new AnisetteService());
-	router.get("/ScaleCloud.ipa", serveStaticFile("/opt/ios-sign/scalecloud/ScaleCloud.ipa"));
+	router.get("/ScaleCloudApp.ipa", serveStaticFile("/opt/ios-sign/scalecloud/ScaleCloudApp.ipa"));
 
 	// Start up the HTTP server.
 	auto settings = new HTTPServerSettings;


### PR DESCRIPTION
libstoreservicescore.so cannot create directories itself, only write files. provisionSession was setting adi.provisioningPath then calling startProvisioning/ endProvisioning without first creating the directory, causing -45054 errors when the directory didn't already exist.

Added file.mkdirRecurse(tmpProvisioningPath) to match the existing correct behaviour in getHeaders.