### PR TITLE
ci: Drop linux/arm/v7 from Docker CI builds and document ARMv7 support

### DIFF
--- a/.github/workflows/docker-publish-anisette-v3-server.yml
+++ b/.github/workflows/docker-publish-anisette-v3-server.yml
@@ -24,4 +24,4 @@ jobs:
           push: true
           tags: |
             dadoum/anisette-v3-server:latest
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/386,linux/amd64,linux/arm64/v8

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ DC=ldc2 dub build -c "static" --build-mode allAtOnce -b release --compiler=ldc2
 stat anisette-v3-server
 ```
 
+## Build the Docker image locally
+
+The GitHub Actions workflow publishes `dadoum/anisette-v3-server` for `linux/386`, `linux/amd64`, and `linux/arm64/v8` only. `linux/arm/v7` is not built by Actions because LDC builds under QEMU are unreliable for that target.
+
+If you need an ARMv7 image, build it locally on a native ARMv7 system or other environment that can produce a compatible binary:
+
+```bash
+docker buildx build --platform linux/arm/v7 -t dadoum/anisette-v3-server:armv7 .
+```
+
 ## Ansible
 
 If you want to quickly setup anisette-v3 with ansible, just use the setup-anisette-v3-ansible.yaml playbook.


### PR DESCRIPTION
This PR removes linux/arm/v7 from the GitHub Actions Docker build matrix and documents the reason in the README.

Building the image for linux/arm/v7 in GitHub Actions consistently fails because ldc2 crashes under QEMU emulation with a bus error during compilation. Since this is an issue with emulated builds rather than the project itself, the CI workflow may publishes images only for linux/386, linux/amd64, linux/arm64/v8. ARMv7 users can still build the image locally on native ARMv7 hardware (or another compatible environment).